### PR TITLE
Added proxy support to Frameworkium

### DIFF
--- a/src/main/java/com/frameworkium/config/SystemProperty.java
+++ b/src/main/java/com/frameworkium/config/SystemProperty.java
@@ -23,20 +23,21 @@ public enum SystemProperty {
     JIRA_RESULT_FIELDNAME("jiraResultFieldName"),
     JIRA_RESULT_TRANSITION("jiraResultTransition"),
     MAXIMISE("maximise"),
-    RESOLUTION("resolution");
-
+    RESOLUTION("resolution"),
+    PROXY_TYPE("proxyType"),
+    PROXY_ADDRESS("proxyAddress");
 
     private String value;
 
-    private SystemProperty(String key) {
+    private SystemProperty(final String key) {
         this.value = System.getProperty(key);
     }
 
     public String getValue() {
-        return value;
+        return this.value;
     }
 
     public boolean isSpecified() {
-        return null != value && !value.isEmpty();
+        return null != this.value && !this.value.isEmpty();
     }
 }

--- a/src/main/java/com/frameworkium/config/drivers/ChromeImpl.java
+++ b/src/main/java/com/frameworkium/config/drivers/ChromeImpl.java
@@ -1,18 +1,19 @@
 package com.frameworkium.config.drivers;
 
-import com.frameworkium.config.DriverType;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import static com.frameworkium.config.SystemProperty.DEVICE;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.frameworkium.config.SystemProperty.DEVICE;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
-public class ChromeImpl extends DriverType {
+public class ChromeImpl extends ProxyableDriver {
 
     @Override
     public DesiredCapabilities getDesiredCapabilities() {
@@ -22,8 +23,8 @@ public class ChromeImpl extends DriverType {
         chromePreferences.put("profile.password_manager_enabled", "false");
         capabilities.setCapability("chrome.prefs", chromePreferences);
 
-        //Use Chrome's built in device emulators
-        //Specify browser=chrome, but also provide device name to use chrome's emulator
+        // Use Chrome's built in device emulators
+        // Specify browser=chrome, but also provide device name to use chrome's emulator
         if (DEVICE.isSpecified()) {
             Map<String, String> mobileEmulation = new HashMap<String, String>();
             mobileEmulation.put("deviceName", DEVICE.getValue());
@@ -33,11 +34,17 @@ public class ChromeImpl extends DriverType {
 
             capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
         }
+
+        Proxy currentProxy = getProxy();
+        if (currentProxy != null) {
+            capabilities.setCapability(CapabilityType.PROXY, currentProxy);
+        }
+
         return capabilities;
     }
 
     @Override
-    public WebDriver getWebDriverObject(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriverObject(final DesiredCapabilities capabilities) {
         return new ChromeDriver(capabilities);
     }
 

--- a/src/main/java/com/frameworkium/config/drivers/FirefoxImpl.java
+++ b/src/main/java/com/frameworkium/config/drivers/FirefoxImpl.java
@@ -1,19 +1,25 @@
 package com.frameworkium.config.drivers;
 
-import com.frameworkium.config.DriverType;
+import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-public class FirefoxImpl extends DriverType {
+public class FirefoxImpl extends ProxyableDriver {
 
     @Override
     public DesiredCapabilities getDesiredCapabilities() {
-        return DesiredCapabilities.firefox();
+        DesiredCapabilities capabilities = DesiredCapabilities.firefox();
+        Proxy currentProxy = getProxy();
+        if (currentProxy != null) {
+            capabilities.setCapability(CapabilityType.PROXY, currentProxy);
+        }
+        return capabilities;
     }
 
     @Override
-    public WebDriver getWebDriverObject(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriverObject(final DesiredCapabilities capabilities) {
         return new FirefoxDriver(capabilities);
     }
 

--- a/src/main/java/com/frameworkium/config/drivers/InternetExporerImpl.java
+++ b/src/main/java/com/frameworkium/config/drivers/InternetExporerImpl.java
@@ -1,12 +1,12 @@
 package com.frameworkium.config.drivers;
 
-import com.frameworkium.config.DriverType;
+import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-public class InternetExporerImpl extends DriverType {
+public class InternetExporerImpl extends ProxyableDriver {
 
     @Override
     public DesiredCapabilities getDesiredCapabilities() {
@@ -14,11 +14,15 @@ public class InternetExporerImpl extends DriverType {
         capabilities.setCapability(CapabilityType.ForSeleniumServer.ENSURING_CLEAN_SESSION, true);
         capabilities.setCapability(InternetExplorerDriver.ENABLE_PERSISTENT_HOVERING, true);
         capabilities.setCapability("requireWindowFocus", true);
+        Proxy currentProxy = getProxy();
+        if (currentProxy != null) {
+            capabilities.setCapability(CapabilityType.PROXY, currentProxy);
+        }
         return capabilities;
     }
 
     @Override
-    public WebDriver getWebDriverObject(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriverObject(final DesiredCapabilities capabilities) {
         return new InternetExplorerDriver(capabilities);
     }
 

--- a/src/main/java/com/frameworkium/config/drivers/OperaImpl.java
+++ b/src/main/java/com/frameworkium/config/drivers/OperaImpl.java
@@ -1,21 +1,26 @@
 package com.frameworkium.config.drivers;
 
-import com.frameworkium.config.DriverType;
+import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.opera.OperaDriver;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-public class OperaImpl extends DriverType {
+public class OperaImpl extends ProxyableDriver {
 
     @Override
     public DesiredCapabilities getDesiredCapabilities() {
         DesiredCapabilities capabilities = DesiredCapabilities.opera();
         capabilities.setCapability("opera.arguments", "-nowin -nomail");
+        Proxy currentProxy = getProxy();
+        if (currentProxy != null) {
+            capabilities.setCapability(CapabilityType.PROXY, currentProxy);
+        }
         return capabilities;
     }
 
     @Override
-    public WebDriver getWebDriverObject(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriverObject(final DesiredCapabilities capabilities) {
         return new OperaDriver(capabilities);
     }
 

--- a/src/main/java/com/frameworkium/config/drivers/PhantomJSImpl.java
+++ b/src/main/java/com/frameworkium/config/drivers/PhantomJSImpl.java
@@ -1,24 +1,29 @@
 package com.frameworkium.config.drivers;
 
-import com.frameworkium.config.DriverType;
+import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-public class PhantomJSImpl extends DriverType {
+public class PhantomJSImpl extends ProxyableDriver {
 
     @Override
     public DesiredCapabilities getDesiredCapabilities() {
         DesiredCapabilities capabilities = DesiredCapabilities.phantomjs();
         capabilities.setCapability("takesScreenshot", true);
         capabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS,
-                new String[]{"--webdriver-loglevel=NONE"});
+                new String[] { "--webdriver-loglevel=NONE" });
+        Proxy currentProxy = getProxy();
+        if (currentProxy != null) {
+            capabilities.setCapability(CapabilityType.PROXY, currentProxy);
+        }
         return capabilities;
     }
 
     @Override
-    public WebDriver getWebDriverObject(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriverObject(final DesiredCapabilities capabilities) {
         return new PhantomJSDriver(capabilities);
     }
 

--- a/src/main/java/com/frameworkium/config/drivers/ProxyableDriver.java
+++ b/src/main/java/com/frameworkium/config/drivers/ProxyableDriver.java
@@ -1,0 +1,51 @@
+package com.frameworkium.config.drivers;
+
+import static com.frameworkium.config.SystemProperty.PROXY_ADDRESS;
+import static com.frameworkium.config.SystemProperty.PROXY_TYPE;
+
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.Proxy.ProxyType;
+
+import com.frameworkium.config.DriverType;
+
+public abstract class ProxyableDriver extends DriverType {
+
+    /**
+     * This method returns a proxy object with settings set by the system properties. If no valid proxy argument is set
+     * then it returns null.
+     *
+     * @return A Selenium proxy object for the current system properties or null if no valid proxy settings
+     */
+    public Proxy getProxy() {
+        if (PROXY_TYPE.isSpecified()) {
+            Proxy proxy = new Proxy();
+            String proxyType = PROXY_TYPE.getValue().toLowerCase();
+            switch (proxyType) {
+                case "manual":
+                    proxy.setProxyType(ProxyType.MANUAL);
+                    if (PROXY_ADDRESS.isSpecified()) {
+                        String proxyAddress = PROXY_ADDRESS.getValue();
+                        proxy.setHttpProxy(proxyAddress).setFtpProxy(proxyAddress).setSslProxy(proxyAddress);
+                    } else {
+                        logger.error("Manual proxy selected but no proxy address specified, using browser default settings");
+                        return null;
+                    }
+                    break;
+                case "system":
+                    proxy.setProxyType(ProxyType.SYSTEM);
+                    break;
+                case "autodetect":
+                    proxy.setProxyType(ProxyType.AUTODETECT);
+                    break;
+                case "direct":
+                    proxy.setProxyType(ProxyType.DIRECT);
+                    break;
+                default:
+                    logger.error("Invalid proxy type specified, using browser default settings");
+                    return null;
+            }
+            return proxy;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/frameworkium/config/drivers/SafariImpl.java
+++ b/src/main/java/com/frameworkium/config/drivers/SafariImpl.java
@@ -1,11 +1,12 @@
 package com.frameworkium.config.drivers;
 
-import com.frameworkium.config.DriverType;
+import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.safari.SafariDriver;
 
-public class SafariImpl extends DriverType {
+public class SafariImpl extends ProxyableDriver {
 
     @Override
     public DesiredCapabilities getDesiredCapabilities() {
@@ -13,13 +14,17 @@ public class SafariImpl extends DriverType {
             return new DesiredCapabilities();
         } else {
             DesiredCapabilities capabilities = DesiredCapabilities.safari();
+            Proxy currentProxy = getProxy();
+            if (currentProxy != null) {
+                capabilities.setCapability(CapabilityType.PROXY, currentProxy);
+            }
             capabilities.setCapability("safari.cleanSession", true);
             return capabilities;
         }
     }
 
     @Override
-    public WebDriver getWebDriverObject(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriverObject(final DesiredCapabilities capabilities) {
         if (isMobile()) {
             throw new IllegalArgumentException(
                     "seleniumGridURL or sauceUser and sauceKey must be specified when running on iOS");


### PR DESCRIPTION
Added proxy support to Frameworkium by creating new system properties for setting a proxy type and proxy address and using these in the browser capabilities.

As this is my first change to Frameworkium I would appreciate comments on the code style and whether it matches what you want as well as checking that this change is correct