### PR TITLE
Fixes timeout issue in the Grid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
-      <version>2.49.0</version>
+      <version>2.49.1</version>
       <exclusions>
         <exclusion>
           <groupId>com.opera</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>com.paulhammant</groupId>
       <artifactId>ngwebdriver</artifactId>
-      <version>0.9.4</version>
+      <version>0.9.3</version>
     </dependency>
     <dependency>
       <groupId>net.sf.uadetector</groupId>


### PR DESCRIPTION
Downgraded paulhammant ngwebdriver to 0.9.3
Upgraded selenium to 2.49.1

This fixes the issue where a driver.switchTo causes browsers to timeout in Grid