### PR TITLE
Updates to correctly support native Electron applications

### DIFF
--- a/src/main/java/com/frameworkium/config/DriverSetup.java
+++ b/src/main/java/com/frameworkium/config/DriverSetup.java
@@ -16,7 +16,7 @@ public class DriverSetup {
     /**
      * List of supported drivers
      */
-    private enum SupportedBrowsers {
+    public enum SupportedBrowsers {
         FIREFOX,CHROME,OPERA,IE,PHANTOMJS,SAFARI,ELECTRON
     }
 

--- a/src/main/java/com/frameworkium/config/DriverType.java
+++ b/src/main/java/com/frameworkium/config/DriverType.java
@@ -1,11 +1,8 @@
 package com.frameworkium.config;
 
-import static com.frameworkium.config.DriverSetup.useRemoteDriver;
-import static com.frameworkium.config.SystemProperty.APP_PATH;
-import static com.frameworkium.config.SystemProperty.GRID_URL;
-import static com.frameworkium.config.SystemProperty.MAXIMISE;
-import static com.frameworkium.config.SystemProperty.PROXY;
-
+import com.frameworkium.capture.ScreenshotCapture;
+import com.frameworkium.listeners.CaptureListener;
+import com.frameworkium.listeners.EventListener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.Proxy;
@@ -14,9 +11,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import com.frameworkium.capture.ScreenshotCapture;
-import com.frameworkium.listeners.CaptureListener;
-import com.frameworkium.listeners.EventListener;
+import static com.frameworkium.config.DriverSetup.useRemoteDriver;
+import static com.frameworkium.config.SystemProperty.*;
 
 public abstract class DriverType {
 
@@ -134,7 +130,7 @@ public abstract class DriverType {
      * Method to tear down the driver object, can be overridden
      */
     public void tearDownDriver() {
-        this.webDriverWrapper.getWrappedDriver().quit();
+        this.webDriverWrapper.quit();
     }
 
     /**

--- a/src/main/java/com/frameworkium/config/drivers/ElectronImpl.java
+++ b/src/main/java/com/frameworkium/config/drivers/ElectronImpl.java
@@ -11,11 +11,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.frameworkium.config.SystemProperty.APP_PATH;
-import static com.frameworkium.config.SystemProperty.GRID_URL;
 
 public class ElectronImpl extends DriverType {
 
     private static URL remoteURL;
+
+    static {
+        try {
+            remoteURL = new URL("http://localhost:9515");
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
 
     @Override
     public DesiredCapabilities getDesiredCapabilities() {
@@ -25,17 +32,6 @@ public class ElectronImpl extends DriverType {
         } else {
             chromeOptions.put("binary", APP_PATH.getValue());
         }
-        try {
-            if (GRID_URL.isSpecified()) {
-                remoteURL = new URL(GRID_URL.getValue());
-            }
-            else {
-                remoteURL = new URL("http://localhost:9515");
-            }
-        }
-        catch(MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
         DesiredCapabilities desiredCapabilities = DesiredCapabilities.chrome();
         desiredCapabilities.setCapability("browserName", "chrome");
         desiredCapabilities.setCapability("chromeOptions", chromeOptions);
@@ -44,6 +40,6 @@ public class ElectronImpl extends DriverType {
 
     @Override
     public WebDriver getWebDriverObject(DesiredCapabilities capabilities) {
-        return new RemoteWebDriver(remoteURL ,capabilities);
+        return new RemoteWebDriver(remoteURL, capabilities);
     }
 }

--- a/src/main/java/com/frameworkium/listeners/ScreenshotListener.java
+++ b/src/main/java/com/frameworkium/listeners/ScreenshotListener.java
@@ -1,10 +1,9 @@
 package com.frameworkium.listeners;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-
+import com.frameworkium.config.DriverSetup.SupportedBrowsers;
+import com.frameworkium.config.SystemProperty;
 import com.frameworkium.config.WebDriverWrapper;
+import com.frameworkium.tests.internal.BaseTest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.OutputType;
@@ -13,11 +12,14 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Augmenter;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
-
 import ru.yandex.qatools.allure.annotations.Attachment;
 
-import com.frameworkium.config.SystemProperty;
-import com.frameworkium.tests.internal.BaseTest;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import static com.frameworkium.config.SystemProperty.BROWSER;
+import static com.frameworkium.config.DriverSetup.SupportedBrowsers.ELECTRON;
 
 public class ScreenshotListener extends TestListenerAdapter {
 
@@ -85,13 +87,27 @@ public class ScreenshotListener extends TestListenerAdapter {
         }
     }
 
+    /**
+     * Are screenshots supported by the browser type being used
+     *
+     * @return boolean - true/false to whether screenshots are supported
+     */
+    private boolean isScreenshotSupported() {
+        if (BROWSER.isSpecified()) {
+            return !SupportedBrowsers.valueOf(BROWSER.getValue().toUpperCase()).equals(ELECTRON);
+        }
+        else {
+            return false;
+        }
+    }
+
     @Override
     public void onTestFailure(ITestResult failingTest) {
-        takeScreenshot(failingTest.getName());
+        if (isScreenshotSupported()) takeScreenshot(failingTest.getName());
     }
 
     @Override
     public void onTestSkipped(ITestResult skippedTest) {
-        takeScreenshot(skippedTest.getName());
+        if (isScreenshotSupported()) takeScreenshot(skippedTest.getName());
     }
 }

--- a/src/main/java/com/frameworkium/pages/internal/BasePage.java
+++ b/src/main/java/com/frameworkium/pages/internal/BasePage.java
@@ -1,10 +1,10 @@
 package com.frameworkium.pages.internal;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
+import com.frameworkium.capture.model.Command;
+import com.frameworkium.config.SystemProperty;
+import com.frameworkium.reporting.AllureLogger;
+import com.frameworkium.tests.internal.BaseTest;
+import com.google.inject.Inject;
 import com.paulhammant.ngwebdriver.WaitForAngularRequestsToFinish;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -15,16 +15,14 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
-
 import ru.yandex.qatools.htmlelements.element.HtmlElement;
 import ru.yandex.qatools.htmlelements.element.TypifiedElement;
 import ru.yandex.qatools.htmlelements.loader.HtmlElementLoader;
 
-import com.frameworkium.capture.model.Command;
-import com.frameworkium.config.SystemProperty;
-import com.frameworkium.reporting.AllureLogger;
-import com.frameworkium.tests.internal.BaseTest;
-import com.google.inject.Inject;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public abstract class BasePage<T extends BasePage<T>> {
 
@@ -184,7 +182,13 @@ public abstract class BasePage<T extends BasePage<T>> {
      * @return boolean - AngularJS true/false
      */
     private boolean isPageAngularJS() {
-        return executeJS("return typeof angular;").equals("object");
+        try {
+            return executeJS("return typeof angular;").equals("object");
+        } catch (NullPointerException e) {
+            logger.error("Detecting whether the page was angular returned a null object. This means your browser" +
+                    "hasn't started! Investigate into the issue.");
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/com/frameworkium/tests/internal/BaseTest.java
+++ b/src/main/java/com/frameworkium/tests/internal/BaseTest.java
@@ -84,8 +84,12 @@ public abstract class BaseTest implements SauceOnDemandSessionIdProvider, SauceO
      */
     @BeforeMethod(alwaysRun = true)
     public static void configureBrowserBeforeTest(Method testMethod) {
-        configureDriverBasedOnParams();
-        initialiseNewScreenshotCapture(testMethod);
+        try {
+            configureDriverBasedOnParams();
+            initialiseNewScreenshotCapture(testMethod);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     /**


### PR DESCRIPTION
The issues with the current implementation:
- Screenshots aren't supported due to electron not allowing native chromium plugins being side-loaded. Added a isScreenshotSupported method to circumvent that. There could be work in the future to sideload our own plugin which would work in electron.
- Native electron apps during development can fail to boot, which causes issues in the driver setup. Try/catches added to correctly show the error and not hang test execution.
- Re-routed the driver type to use the grid implementation rather than using the electron driver when remote.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/robertgates55/frameworkium-core/34)
<!-- Reviewable:end -->
